### PR TITLE
Add dark/light theme

### DIFF
--- a/example/app/src/main/java/com/rootstrap/androidcomposebase/ui/MainActivity.kt
+++ b/example/app/src/main/java/com/rootstrap/androidcomposebase/ui/MainActivity.kt
@@ -37,9 +37,9 @@ class MainActivity : ComponentActivity() {
 
             // TODO Use SharePreference or DataStore
             val boolean = isSystemInDarkTheme()
-            var darkTheme by remember { mutableStateOf(boolean) }
+            var isOSDarkTheme by remember { mutableStateOf(boolean) }
 
-            AppTheme(useDarkTheme = darkTheme) {
+            AppTheme(isOSDarkTheme = isOSDarkTheme) {
                 // A surface container using the 'background' color from the theme
                 Surface(
                     modifier = Modifier.fillMaxSize(),
@@ -47,8 +47,8 @@ class MainActivity : ComponentActivity() {
                 ) {
                     //LogInScreen()
                     SettingsScreen(
-                        darkTheme = darkTheme,
-                        onThemeUpdated = { darkTheme = !darkTheme }
+                        isOSDarkTheme = isOSDarkTheme,
+                        onThemeUpdated = { isOSDarkTheme = !isOSDarkTheme }
                     )
                 }
 

--- a/example/app/src/main/java/com/rootstrap/androidcomposebase/ui/MainActivity.kt
+++ b/example/app/src/main/java/com/rootstrap/androidcomposebase/ui/MainActivity.kt
@@ -3,6 +3,7 @@ package com.rootstrap.androidcomposebase.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.AlertDialog
@@ -12,11 +13,14 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.rootstrap.androidcomposebase.ui.base.ErrorMapper
-import com.rootstrap.androidcomposebase.ui.pages.login.LogInScreen
+import com.rootstrap.androidcomposebase.ui.pages.settings.SettingsScreen
 import com.rootstrap.androidcomposebase.ui.theme.AppTheme
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -31,13 +35,21 @@ class MainActivity : ComponentActivity() {
         setContent {
             val errorNotification by viewModel.errorNotification.collectAsStateWithLifecycle()
 
-            AppTheme {
+            // TODO Use SharePreference or DataStore
+            val boolean = isSystemInDarkTheme()
+            var darkTheme by remember { mutableStateOf(boolean) }
+
+            AppTheme(useDarkTheme = darkTheme) {
                 // A surface container using the 'background' color from the theme
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    LogInScreen()
+                    //LogInScreen()
+                    SettingsScreen(
+                        darkTheme = darkTheme,
+                        onThemeUpdated = { darkTheme = !darkTheme }
+                    )
                 }
 
                 errorNotification?.let {

--- a/example/app/src/main/java/com/rootstrap/androidcomposebase/ui/pages/settings/SettingsScreen.kt
+++ b/example/app/src/main/java/com/rootstrap/androidcomposebase/ui/pages/settings/SettingsScreen.kt
@@ -8,13 +8,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -22,7 +19,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Nightlight
@@ -41,13 +37,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.rootstrap.androidcomposebase.ui.theme.AppTheme
+import com.rootstrap.androidcomposebase.ui.theme.compactDimensions
+import com.rootstrap.androidcomposebase.ui.theme.defaultDimensions
+import com.rootstrap.androidcomposebase.ui.theme.expandedDimensions
+import com.rootstrap.example.app.R
+
+private const val ANIMATION_TIME_IN_MILLIS = 300
 
 @Composable
-fun SettingsScreen(darkTheme: Boolean, onThemeUpdated: () -> Unit) {
+fun SettingsScreen(isOSDarkTheme: Boolean, onThemeUpdated: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -56,14 +59,13 @@ fun SettingsScreen(darkTheme: Boolean, onThemeUpdated: () -> Unit) {
         CenterAlignedAppBar()
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(16.dp)
+            modifier = Modifier.padding(defaultDimensions.big)
             ) {
-                Text(text = "Dark/Light Appearance",
-                    modifier = Modifier.weight(1f))
+                Text(text = stringResource(id = R.string.settings_dark_light_theme), modifier = Modifier.weight(1f))
                 ThemeSwitcher(
-                    darkTheme = darkTheme,
-                    size = 50.dp,
-                    padding = 5.dp,
+                    isOSDarkTheme = isOSDarkTheme,
+                    size = expandedDimensions.paddingSixQuarters,
+                    padding = compactDimensions.paddingFiveQuarters,
                     onClick = onThemeUpdated
             )
         }
@@ -80,34 +82,33 @@ fun CenterAlignedAppBar() {
         title = {
             Box(modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.CenterStart) {
-                Text("Settings")
+                Text(stringResource(id = R.string.settings_title))
             }
         },
 
         // The navigation icon is set to a menu icon.
         navigationIcon = {
             IconButton(onClick = { /* Handle navigation icon click */ }) {
-                Icon(Icons.Filled.Menu, contentDescription = "Navigation Icon")
+                Icon(Icons.Filled.Menu, contentDescription = stringResource(id = R.string.content_description_navigation_icon))
             }
         }
     )
 }
 
-
 @Composable
 fun ThemeSwitcher(
-    darkTheme: Boolean = false,
-    size: Dp = 150.dp,
+    isOSDarkTheme: Boolean = false,
+    size: Dp = expandedDimensions.paddingTwentyQuarters,
     iconSize: Dp = size / 3,
-    padding: Dp = 10.dp,
-    borderWidth: Dp = 1.dp,
+    padding: Dp = defaultDimensions.paddingEightQuarters,
+    borderWidth: Dp = defaultDimensions.small,
     parentShape: Shape = CircleShape,
     toggleShape: Shape = CircleShape,
-    animationSpec: AnimationSpec<Dp> = tween(durationMillis = 300),
+    animationSpec: AnimationSpec<Dp> = tween(durationMillis = ANIMATION_TIME_IN_MILLIS),
     onClick: () -> Unit
 ) {
     val offset by animateDpAsState(
-        targetValue = if (darkTheme) 0.dp else size,
+        targetValue = if (isOSDarkTheme) 0.dp else size,
         animationSpec = animationSpec, label = ""
     )
 
@@ -143,9 +144,8 @@ fun ThemeSwitcher(
                 Icon(
                     modifier = Modifier.size(iconSize),
                     imageVector = Icons.Default.Nightlight,
-                    contentDescription = "Theme Icon",
-                    tint = if (darkTheme) MaterialTheme.colorScheme.secondaryContainer
-                    else MaterialTheme.colorScheme.primary
+                    contentDescription = stringResource(id = R.string.content_description_theme_icon),
+                    tint = MaterialTheme.colorScheme.inverseSurface
                 )
             }
             Box(
@@ -155,9 +155,8 @@ fun ThemeSwitcher(
                 Icon(
                     modifier = Modifier.size(iconSize),
                     imageVector = Icons.Default.LightMode,
-                    contentDescription = "Theme Icon",
-                    tint = if (darkTheme) MaterialTheme.colorScheme.primary
-                    else MaterialTheme.colorScheme.secondaryContainer
+                    contentDescription = stringResource(id = R.string.content_description_theme_icon),
+                    tint = MaterialTheme.colorScheme.inversePrimary
                 )
             }
         }
@@ -171,7 +170,7 @@ private fun SettingsScreenPreview() {
     val boolean = isSystemInDarkTheme()
     var darkTheme by remember { mutableStateOf(boolean) }
     AppTheme {
-        SettingsScreen(darkTheme = darkTheme,
+        SettingsScreen(isOSDarkTheme = darkTheme,
             onThemeUpdated = { darkTheme = !darkTheme })
     }
 }

--- a/example/app/src/main/java/com/rootstrap/androidcomposebase/ui/pages/settings/SettingsScreen.kt
+++ b/example/app/src/main/java/com/rootstrap/androidcomposebase/ui/pages/settings/SettingsScreen.kt
@@ -1,0 +1,177 @@
+package com.rootstrap.androidcomposebase.ui.pages.settings
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.LightMode
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Nightlight
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.rootstrap.androidcomposebase.ui.theme.AppTheme
+
+@Composable
+fun SettingsScreen(darkTheme: Boolean, onThemeUpdated: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        CenterAlignedAppBar()
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(16.dp)
+            ) {
+                Text(text = "Dark/Light Appearance",
+                    modifier = Modifier.weight(1f))
+                ThemeSwitcher(
+                    darkTheme = darkTheme,
+                    size = 50.dp,
+                    padding = 5.dp,
+                    onClick = onThemeUpdated
+            )
+        }
+    }
+}
+
+// Opt-in to use experimental Material 3 API
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CenterAlignedAppBar() {
+    // TopAppBar is a composable that represents a top app bar.
+    TopAppBar(
+        // The title of the top app bar is set to "My App".
+        title = {
+            Box(modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.CenterStart) {
+                Text("Settings")
+            }
+        },
+
+        // The navigation icon is set to a menu icon.
+        navigationIcon = {
+            IconButton(onClick = { /* Handle navigation icon click */ }) {
+                Icon(Icons.Filled.Menu, contentDescription = "Navigation Icon")
+            }
+        }
+    )
+}
+
+
+@Composable
+fun ThemeSwitcher(
+    darkTheme: Boolean = false,
+    size: Dp = 150.dp,
+    iconSize: Dp = size / 3,
+    padding: Dp = 10.dp,
+    borderWidth: Dp = 1.dp,
+    parentShape: Shape = CircleShape,
+    toggleShape: Shape = CircleShape,
+    animationSpec: AnimationSpec<Dp> = tween(durationMillis = 300),
+    onClick: () -> Unit
+) {
+    val offset by animateDpAsState(
+        targetValue = if (darkTheme) 0.dp else size,
+        animationSpec = animationSpec, label = ""
+    )
+
+    Box(modifier = Modifier
+        .width(size * 2)
+        .height(size)
+        .clip(shape = parentShape)
+        .clickable { onClick() }
+        .background(MaterialTheme.colorScheme.secondaryContainer)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(size)
+                .offset(x = offset)
+                .padding(all = padding)
+                .clip(shape = toggleShape)
+                .background(MaterialTheme.colorScheme.primary)
+        ) {}
+        Row(
+            modifier = Modifier
+                .border(
+                    border = BorderStroke(
+                        width = borderWidth,
+                        color = MaterialTheme.colorScheme.primary
+                    ),
+                    shape = parentShape
+                )
+        ) {
+            Box(
+                modifier = Modifier.size(size),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    modifier = Modifier.size(iconSize),
+                    imageVector = Icons.Default.Nightlight,
+                    contentDescription = "Theme Icon",
+                    tint = if (darkTheme) MaterialTheme.colorScheme.secondaryContainer
+                    else MaterialTheme.colorScheme.primary
+                )
+            }
+            Box(
+                modifier = Modifier.size(size),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    modifier = Modifier.size(iconSize),
+                    imageVector = Icons.Default.LightMode,
+                    contentDescription = "Theme Icon",
+                    tint = if (darkTheme) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.secondaryContainer
+                )
+            }
+        }
+    }
+}
+
+
+@Preview(showSystemUi = true)
+@Composable
+private fun SettingsScreenPreview() {
+    val boolean = isSystemInDarkTheme()
+    var darkTheme by remember { mutableStateOf(boolean) }
+    AppTheme {
+        SettingsScreen(darkTheme = darkTheme,
+            onThemeUpdated = { darkTheme = !darkTheme })
+    }
+}

--- a/example/app/src/main/java/com/rootstrap/androidcomposebase/ui/theme/Theme.kt
+++ b/example/app/src/main/java/com/rootstrap/androidcomposebase/ui/theme/Theme.kt
@@ -85,10 +85,10 @@ private val DarkColors = darkColorScheme(
 
 @Composable
 fun AppTheme(
-    useDarkTheme: Boolean = isSystemInDarkTheme(),
+    isOSDarkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    val colorScheme = if (useDarkTheme) {
+    val colorScheme = if (isOSDarkTheme) {
         DarkColors
     } else {
         LightColors
@@ -98,7 +98,7 @@ fun AppTheme(
     if (!view.isInEditMode) {
         SideEffect {
             (view.context as Activity).window.statusBarColor = colorScheme.primary.toArgb()
-            ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = useDarkTheme
+            ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = isOSDarkTheme
         }
     }
 

--- a/example/app/src/main/java/com/rootstrap/androidcomposebase/ui/theme/Theme.kt
+++ b/example/app/src/main/java/com/rootstrap/androidcomposebase/ui/theme/Theme.kt
@@ -1,5 +1,6 @@
 package com.rootstrap.androidcomposebase.ui.theme
 
+import android.app.Activity
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -8,9 +9,13 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.ViewCompat
 import com.rootstrap.androidcomposebase.ui.model.Dimensions
 import com.rootstrap.yourAppName.ui.model.WindowType
 
@@ -83,11 +88,20 @@ fun AppTheme(
     useDarkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    val colors = if (!useDarkTheme) {
-        LightColors
-    } else {
+    val colorScheme = if (useDarkTheme) {
         DarkColors
+    } else {
+        LightColors
     }
+
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            (view.context as Activity).window.statusBarColor = colorScheme.primary.toArgb()
+            ViewCompat.getWindowInsetsController(view)?.isAppearanceLightStatusBars = useDarkTheme
+        }
+    }
+
     val dimensions = WindowType.getDimensions(context = LocalContext.current)
 
     val shapes = Shapes(
@@ -100,7 +114,7 @@ fun AppTheme(
 
     ProvideDimens(dimensions = dimensions) {
         MaterialTheme(
-            colorScheme = colors,
+            colorScheme = colorScheme,
             content = content,
             typography = Typography,
             shapes = shapes,

--- a/example/app/src/main/res/values/strings.xml
+++ b/example/app/src/main/res/values/strings.xml
@@ -18,4 +18,10 @@
     <string name="log_in_password_error_min_length">Password must contain at least %s characters</string>
     <string name="log_in_button">LOG IN</string>
 
+    <!-- Settings -->
+    <string name="settings_title">Settings</string>
+    <string name="settings_dark_light_theme">Dark/Light Appearance</string>
+    <string name="content_description_navigation_icon">Navigation Icon</string>
+    <string name="content_description_theme_icon">Theme Icon</string>
+
 </resources>


### PR DESCRIPTION
- A configuration view is created to contain the desired configuration options.
- Added the possibility to use a dark or light theme

https://github.com/rootstrap/android-base-compose/assets/47226803/4d449487-7686-4aca-934c-f2fe721457a4


// TODO: 
- It will be necessary to define a navigation flow to see from where and when this section should be accessed. 
- Implement SharedPreference or DataStore to store desired configuration options