### PR TITLE
Enhancement: Update Kotlin 2.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,10 @@
-import Dependencies.Common.JAVA_TARGET
 import Dependencies.Common.JAVA_VERSION
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
     kotlin(Dependencies.Plugins.ANDROID)
+    id(Dependencies.Plugins.COMPOSE) version Dependencies.Versions.KOTLIN
 }
 
 android {
@@ -35,17 +36,15 @@ android {
         targetCompatibility = JAVA_VERSION
     }
 
-    kotlinOptions {
-        jvmTarget = JAVA_TARGET
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
     }
 
     buildFeatures {
         compose = true
         buildConfig = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = Dependencies.Versions.COMPOSE_COMPILER
     }
 }
 
@@ -53,6 +52,7 @@ dependencies {
     implementation(project(":core:domain"))
     implementation(project(":core:usecases"))
     implementation(project(":core:di"))
+    implementation("androidx.compose.foundation:foundation-android:1.6.7")
 
     with(Dependencies.Android) {
         implementation(CORE)
@@ -63,6 +63,7 @@ dependencies {
         implementation(SPLASH_SCREEN)
         implementation(WINDOW)
     }
+
     with(Dependencies.Compose) {
         implementation(ACTIVITY)
         implementation(UI)
@@ -73,6 +74,7 @@ dependencies {
         implementation(LIFECYCLE_RUNTIME)
         debugImplementation(UI_TOOLING)
     }
+
     with(Dependencies.Koin) {
         implementation(CORE)
         implementation(ANDROID)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
     implementation(project(":core:domain"))
     implementation(project(":core:usecases"))
     implementation(project(":core:di"))
-    implementation("androidx.compose.foundation:foundation-android:1.6.7")
 
     with(Dependencies.Android) {
         implementation(CORE)

--- a/buildSrc/src/main/java/com/rootstrap/buildsrc/Libs.kt
+++ b/buildSrc/src/main/java/com/rootstrap/buildsrc/Libs.kt
@@ -80,8 +80,8 @@ object Dependencies {
     }
 
     object Tv {
-        const val TV_FOUNDATION = "androidx.tv:tv-foundation:${Versions.COMPOSE_TV}"
-        const val TV_MATERIAL = "androidx.tv:tv-material:${Versions.COMPOSE_TV}"
+        const val TV_FOUNDATION = "androidx.tv:tv-foundation:1.0.0-alpha10"
+        const val TV_MATERIAL = "androidx.tv:tv-material:1.0.0-beta01"
         const val LEANBACK = "androidx.leanback:leanback:${Versions.LEANBACK}"
     }
 
@@ -183,7 +183,7 @@ object Dependencies {
         const val APP_COMPAT = "1.6.1"
         const val CONSTRAINT_LAYOUT = "2.1.1"
         const val COMPOSE = "1.4.0"
-        const val COMPOSE_COMPILER = "1.5.4"
+
         const val COMPOSE_ACTIVITY = "1.8.0"
         const val COMPOSE_MATERIAL3 = "1.1.1"
         const val COMPOSE_NAVIGATION = "2.7.5"
@@ -204,7 +204,7 @@ object Dependencies {
         const val GSON = "2.8.7"
         const val JUNIT = "4.13.2"
         const val KOIN = "3.5.0"
-        const val KOTLIN = "1.9.20"
+        const val KOTLIN = "2.0.0"
         const val KT_LINT = "0.44.0"
         const val LEGACY_SUPPORT_V4 = "1.0.0"
         const val LIFECYCLE = "2.6.1"
@@ -258,5 +258,6 @@ object Dependencies {
         const val KAPT = "kapt"
         const val JAVA_LIBRARY = "java-library"
         const val KOTLIN_JVM = "org.jetbrains.kotlin.jvm"
+        const val COMPOSE = "org.jetbrains.kotlin.plugin.compose"
     }
 }

--- a/buildSrc/src/main/java/com/rootstrap/buildsrc/Libs.kt
+++ b/buildSrc/src/main/java/com/rootstrap/buildsrc/Libs.kt
@@ -80,8 +80,8 @@ object Dependencies {
     }
 
     object Tv {
-        const val TV_FOUNDATION = "androidx.tv:tv-foundation:1.0.0-alpha10"
-        const val TV_MATERIAL = "androidx.tv:tv-material:1.0.0-beta01"
+        const val TV_FOUNDATION = "androidx.tv:tv-foundation:${Versions.COMPOSE_TV}"
+        const val TV_MATERIAL = "androidx.tv:tv-material:${Versions.COMPOSE_TV}"
         const val LEANBACK = "androidx.leanback:leanback:${Versions.LEANBACK}"
     }
 

--- a/example/app/build.gradle.kts
+++ b/example/app/build.gradle.kts
@@ -1,4 +1,3 @@
-
 import Dependencies.Common.JAVA_VERSION
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -37,13 +36,14 @@ android {
         targetCompatibility = JAVA_VERSION
     }
 
-    kotlin{
-        compilerOptions{
+    kotlin {
+        compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
-            freeCompilerArgs.addAll( listOf(
-                "-P",
-                "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" + project.buildDir.absolutePath + "/compose_metrics"
-            )
+            freeCompilerArgs.addAll(
+                listOf(
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" + project.buildDir.absolutePath + "/compose_metrics"
+                )
             )
             freeCompilerArgs.addAll(
                 listOf(
@@ -65,7 +65,6 @@ dependencies {
     implementation(project(":core:domain"))
     implementation(project(":example:core:domain"))
     implementation(project(":example:core:usecases"))
-    implementation("androidx.compose.foundation:foundation-android:1.6.7")
     implementation("androidx.benchmark:benchmark-baseline-profile-gradle-plugin:1.2.4")
 
     with(Dependencies.Android) {

--- a/example/app/build.gradle.kts
+++ b/example/app/build.gradle.kts
@@ -1,10 +1,11 @@
 
-import Dependencies.Common.JAVA_TARGET
 import Dependencies.Common.JAVA_VERSION
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
     kotlin(Dependencies.Plugins.ANDROID)
+    id(Dependencies.Plugins.COMPOSE) version Dependencies.Versions.KOTLIN
 }
 
 android {
@@ -36,31 +37,26 @@ android {
         targetCompatibility = JAVA_VERSION
     }
 
-    kotlinOptions {
-        jvmTarget = JAVA_TARGET
-        /**
-         * Compose-metrics
-         * How to execute:
-         * ./gradlew assembleRelease -PcomposeCompilerReports=true
-         * Review reports in: app/build/compose_metrics
-         * */
-        freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" + project.buildDir.absolutePath + "/compose_metrics"
-        )
-        freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" + project.buildDir.absolutePath + "/compose_metrics"
-        )
+    kotlin{
+        compilerOptions{
+            jvmTarget.set(JvmTarget.JVM_17)
+            freeCompilerArgs.addAll( listOf(
+                "-P",
+                "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" + project.buildDir.absolutePath + "/compose_metrics"
+            )
+            )
+            freeCompilerArgs.addAll(
+                listOf(
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" + project.buildDir.absolutePath + "/compose_metrics"
+                )
+            )
+        }
     }
 
     buildFeatures {
         compose = true
         buildConfig = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = Dependencies.Versions.COMPOSE_COMPILER
     }
 }
 
@@ -69,6 +65,8 @@ dependencies {
     implementation(project(":core:domain"))
     implementation(project(":example:core:domain"))
     implementation(project(":example:core:usecases"))
+    implementation("androidx.compose.foundation:foundation-android:1.6.7")
+    implementation("androidx.benchmark:benchmark-baseline-profile-gradle-plugin:1.2.4")
 
     with(Dependencies.Android) {
         implementation(CORE)

--- a/example/app/build.gradle.kts
+++ b/example/app/build.gradle.kts
@@ -65,7 +65,6 @@ dependencies {
     implementation(project(":core:domain"))
     implementation(project(":example:core:domain"))
     implementation(project(":example:core:usecases"))
-    implementation("androidx.benchmark:benchmark-baseline-profile-gradle-plugin:1.2.4")
 
     with(Dependencies.Android) {
         implementation(CORE)

--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -1,6 +1,8 @@
+import Dependencies.Common.JAVA_VERSION
 import Dependencies.ConfigData.COMPILE_SDK_VERSION
 import Dependencies.ConfigData.MIN_SDK_VERSION
 import Dependencies.ConfigData.TARGET_SDK_VERSION
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
@@ -33,11 +35,11 @@ android {
         compose = true
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JAVA_VERSION
+        targetCompatibility = JAVA_VERSION
     }
-    kotlin{
-        compilerOptions{
+    kotlin {
+        compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
         }
     }

--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -5,6 +5,7 @@ import Dependencies.ConfigData.TARGET_SDK_VERSION
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id(Dependencies.Plugins.COMPOSE) version Dependencies.Versions.KOTLIN
 }
 
 android {
@@ -31,15 +32,14 @@ android {
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = Dependencies.Versions.COMPOSE_COMPILER
-    }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    kotlin{
+        compilerOptions{
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
     }
 }
 


### PR DESCRIPTION
Updated Kotlin to 2.0 and removed `kotlinCompilerExtensionVersion` since it is not needed anymore.
I used this migration guide: https://medium.com/@jonathan.mercandalli_41381/kotlin-2-0-0-how-to-bump-as-an-android-dev-36cd0874619d 